### PR TITLE
Fix S3 ACL issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ After you deploy this Partner Solution, confirm that your resources and services
 |------|--------|---------|
 | <a name="module_container_registry"></a> [container\_registry](#module\_container\_registry) | ./modules/container-registry | n/a |
 | <a name="module_databases"></a> [databases](#module\_databases) | ./modules/databases | n/a |
-| <a name="module_eks_blueprints"></a> [eks\_blueprints](#module\_eks\_blueprints) | github.com/aws-ia/terraform-aws-eks-blueprints | v4.18.1 |
-| <a name="module_eks_blueprints_kubernetes_addons"></a> [eks\_blueprints\_kubernetes\_addons](#module\_eks\_blueprints\_kubernetes\_addons) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons | v4.18.1 |
+| <a name="module_eks_blueprints"></a> [eks\_blueprints](#module\_eks\_blueprints) | github.com/aws-ia/terraform-aws-eks-blueprints | v4.28.0 |
+| <a name="module_eks_blueprints_kubernetes_addons"></a> [eks\_blueprints\_kubernetes\_addons](#module\_eks\_blueprints\_kubernetes\_addons) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons | v4.28.0 |
 | <a name="module_file_storage"></a> [file\_storage](#module\_file\_storage) | ./modules/file-storage | n/a |
 | <a name="module_monitoring"></a> [monitoring](#module\_monitoring) | ./modules/monitoring | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | ./modules/vpc | n/a |

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "aws_ebs_encryption_by_default" "ebs_encryption" {
 }
 
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.27.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.28.0"
 
   node_security_group_additional_rules = {
     cluster_to_nginx_webhook = {
@@ -94,7 +94,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=d99f72cc467f9fc1a8a720d24ca7dae253af3ff7"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.28.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.27.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=d99f72cc467f9fc1a8a720d24ca7dae253af3ff7"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "aws_ebs_encryption_by_default" "ebs_encryption" {
 }
 
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.18.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.27.0"
 
   node_security_group_additional_rules = {
     cluster_to_nginx_webhook = {
@@ -94,7 +94,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.18.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.27.0"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint

--- a/modules/file-storage/main.tf
+++ b/modules/file-storage/main.tf
@@ -5,6 +5,16 @@ resource "aws_s3_bucket" "apps_shared_bucket" {
   force_destroy = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "apps_shared_bucket" {
+  bucket = aws_s3_bucket.apps_shared_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+
+  depends_on = [aws_s3_bucket_acl.apps_shared_bucket_acl]
+}
+
 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "apps_shared_bucket" {
   bucket = aws_s3_bucket.apps_shared_bucket.bucket

--- a/modules/file-storage/main.tf
+++ b/modules/file-storage/main.tf
@@ -11,8 +11,6 @@ resource "aws_s3_bucket_ownership_controls" "apps_shared_bucket" {
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
-
-  depends_on = [aws_s3_bucket_acl.apps_shared_bucket_acl]
 }
 
 #tfsec:ignore:aws-s3-encryption-customer-key

--- a/modules/file-storage/main.tf
+++ b/modules/file-storage/main.tf
@@ -36,4 +36,6 @@ resource "aws_s3_bucket_public_access_block" "apps_shared_bucket" {
 resource "aws_s3_bucket_acl" "apps_shared_bucket_acl" {
   bucket = aws_s3_bucket.apps_shared_bucket.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.apps_shared_bucket]
 }


### PR DESCRIPTION
Fixes `Error: error creating S3 bucket ACL for mybucketname: AccessControlListNotSupported: The bucket does not allow ACLs` error.

Includes https://github.com/aws-ia/terraform-aws-mendix-private-cloud/pull/27 PR. 