### PR TITLE
Fix: mxpc throws an error because parameter clustertag is unknown

### DIFF
--- a/charts/mendix-installer/templates/mendix-installer-configmap.yaml
+++ b/charts/mendix-installer/templates/mendix-installer-configmap.yaml
@@ -9,7 +9,7 @@ data:
     
     wget https://cdn.mendix.com/mendix-for-private-cloud/mxpc-cli/mxpc-cli-{{ .Values.mendixOperatorVersion }}-linux-amd64.tar.gz
     tar xvf mxpc-cli-{{ .Values.mendixOperatorVersion }}-linux-amd64.tar.gz
-    ./mxpc-cli base-install --namespace mendix -i {{ .Values.namespaceID }} -s {{ .Values.namespaceSecret }} --clusterMode connected --clusterType generic --clusterTag="aws-reference-deployment"
+    ./mxpc-cli base-install --namespace mendix -i {{ .Values.namespaceID }} -s {{ .Values.namespaceSecret }} --clusterMode connected --clusterType generic
     
     wget --output-document=custom.crt https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
     kubectl -n mendix create secret generic mendix-custom-tls --from-file=custom.crt=custom.crt


### PR DESCRIPTION
Hi,

I could not connect my cluster to the Mendix for Private Cloud Platform when deploying this solution.
I did some research in the logs and found the root cause in the parameter `clusterTag` because it does not exist (anymore?) in mxpc-cli. After I removed the paramter I was able to connect to the Mendix platform as expected.

Therefore my suggestion would be to remote this parameter.

Best,
Hendrik

