### PR TITLE
Update dependencies and fix installation for Mendix operator version 2.15+

### DIFF
--- a/charts/mendix-installer/templates/mendix-installer-configmap.yaml
+++ b/charts/mendix-installer/templates/mendix-installer-configmap.yaml
@@ -6,7 +6,16 @@ metadata:
 data:
   mxpc-cli-installer-script: | 
     #/bin/sh
-    
+
+    echo "Configuring kubeconfig for mxpc-cli..."
+    KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+    KUBE_SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+    kubectl config set-cluster default --server="${KUBE_SERVER}" --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    kubectl config set-credentials default --token="${KUBE_TOKEN}"
+    kubectl config set-context default --cluster=default --user=default
+    kubectl config use-context default
+    echo "Kubeconfig for mxpc-cli configured."
+
     wget https://cdn.mendix.com/mendix-for-private-cloud/mxpc-cli/mxpc-cli-{{ .Values.mendixOperatorVersion }}-linux-amd64.tar.gz
     tar xvf mxpc-cli-{{ .Values.mendixOperatorVersion }}-linux-amd64.tar.gz
     ./mxpc-cli base-install --namespace mendix -i {{ .Values.namespaceID }} -s {{ .Values.namespaceSecret }} --clusterMode connected --clusterType generic --clusterTag="aws-reference-deployment"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -3,11 +3,13 @@ module "mendix_private_cloud_example" {
 
   aws_region                   = var.aws_region
   domain_name                  = var.domain_name
+  allowed_ips                  = var.allowed_ips
   certificate_expiration_email = var.certificate_expiration_email
   s3_bucket_name               = var.s3_bucket_name
   namespace_id                 = var.namespace_id
   namespace_secret             = var.namespace_secret
   mendix_operator_version      = var.mendix_operator_version
+  environments_internal_names  = var.environments_internal_names
 }
 
 provider "aws" {}

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -26,7 +26,7 @@ variable "namespace_secret" {
 variable "mendix_operator_version" {
   type        = string
   description = "Mendix Private Cloud Operator version"
-  default     = "2.10.0"
+  default     = "2.16.0"
 }
 
 variable "certificate_expiration_email" {

--- a/main.tf
+++ b/main.tf
@@ -108,11 +108,11 @@ resource "aws_ebs_encryption_by_default" "ebs_encryption" {
 
 module "eks_blueprints" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 19.21"
 
   # EKS CLUSTER
   cluster_name    = local.cluster_name
-  cluster_version = "1.26"
+  cluster_version = var.eks_version
   vpc_id          = module.vpc.vpc_id
   subnet_ids      = module.vpc.vpc_private_subnets
 
@@ -221,7 +221,7 @@ module "monitoring" {
   cloudwatch_log_group_arn  = aws_cloudwatch_log_group.aws_for_fluentbit.arn
   cloudwatch_log_group_name = aws_cloudwatch_log_group.aws_for_fluentbit.name
 
-  depends_on = [module.eks_blueprints_kubernetes_addons]
+  depends_on = [module.eks_blueprints_kubernetes_addons, aws_eks_addon.adot_addon]
 }
 
 resource "kubernetes_namespace" "mendix" {
@@ -267,14 +267,14 @@ resource "helm_release" "mendix_installer" {
 resource "aws_eks_addon" "adot_addon" {
   cluster_name  = module.eks_blueprints.cluster_name
   addon_name    = "adot"
-  addon_version = "v0.80.0-eksbuild.2"
+  addon_version = "v0.94.1-eksbuild.1"
 
   depends_on = [module.eks_blueprints, module.eks_blueprints_kubernetes_addons]
 }
 
 module "ebs_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
+  version = "~> 5.39"
 
   role_name_prefix = "${module.eks_blueprints.cluster_name}-ebs-csi-driver-"
 

--- a/modules/container-registry/providers.tf
+++ b/modules/container-registry/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.35"
+      version = ">= 5.46"
     }
   }
 }

--- a/modules/databases/providers.tf
+++ b/modules/databases/providers.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.35"
+      version = ">= 5.46"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4.3"
+      version = ">= 3.6"
     }
   }
 }

--- a/modules/file-storage/providers.tf
+++ b/modules/file-storage/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.35"
+      version = ">= 5.46"
     }
   }
 }

--- a/modules/monitoring/providers.tf
+++ b/modules/monitoring/providers.tf
@@ -4,19 +4,19 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.35"
+      version = ">= 5.46"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.10"
+      version = ">= 2.29.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7.1"
+      version = ">= 2.13"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4.3"
+      version = ">= 3.6"
     }
   }
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.1.2"
+  version = "5.7.1"
 
   name                 = "${var.cluster_name}-vpc"
   cidr                 = "10.0.0.0/16"

--- a/modules/vpc/providers.tf
+++ b/modules/vpc/providers.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.35"
+      version = ">= 5.46"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4.3"
+      version = ">= 3.6"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -13,27 +13,19 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.10"
+      version = ">= 5.46"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.16.1"
+      version = ">= 2.29.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7.1"
+      version = ">= 2.13"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.4.3"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2.0"
-    }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      version = ">= 3.6"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "eks_cluster_name_prefix" {
 variable "mendix_operator_version" {
   type        = string
   description = "Mendix Private Cloud Operator version"
-  default     = "2.13.0"
+  default     = "2.16.0"
 }
 
 variable "certificate_expiration_email" {
@@ -71,5 +71,12 @@ variable "environments_internal_names" {
 variable "postgres_version" {
   type        = string
   description = "The version of Postgres that terraform would create."
-  default     = "14.8"
+  default     = "14.11"
 }
+
+variable "eks_version" {
+  type        = string
+  description = "The version of EKS that terraform would create."
+  default     = "1.29"
+}
+


### PR DESCRIPTION
Issues addressed:
* Update Postgres version since 14.8 version is not available in some regions.
* Fix installation for Mendix Operator v2.15+.
* Update some other dependencies.