### PR TITLE
Fix dependencies by avoiding new major versions.

### DIFF
--- a/modules/container-registry/providers.tf
+++ b/modules/container-registry/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.46, < 6.0.0"
     }
   }
 }

--- a/modules/databases/providers.tf
+++ b/modules/databases/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.46, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/file-storage/providers.tf
+++ b/modules/file-storage/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.46, < 6.0.0"
     }
   }
 }

--- a/modules/monitoring/providers.tf
+++ b/modules/monitoring/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.46, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.13"
+      version = ">= 2.13, < 3.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/vpc/providers.tf
+++ b/modules/vpc/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.46, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/providers.tf
+++ b/providers.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.83"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -21,7 +21,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.13"
+      version = ">= 2.13, < 3.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Ad the moment when you run fresh `terraform init` and then run `terraform apply` command you would get the next errors:
```
│ Error: Unsupported block type
│
│   on providers.tf line 44, in provider "helm":
│   44:   kubernetes {
│
│ Blocks of type "kubernetes" are not expected here. Did you mean to define
│ argument "kubernetes"? If so, use the equals sign to assign it a value.
╵
╷
│ Error: Unsupported argument
│
│   on .terraform/modules/eks_blueprints/main.tf line 428, in resource "aws_eks_addon" "before_compute":
│  428:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│
│ An argument named "resolve_conflicts" is not expected here.
╵
╷
│ Error: Unsupported block type
│
│   on .terraform/modules/eks_blueprints/modules/eks-managed-node-group/main.tf line 104, in resource "aws_launch_template" "this":
│  104:   dynamic "elastic_gpu_specifications" {
│
│ Blocks of type "elastic_gpu_specifications" are not expected here.
╵
╷
│ Error: Unsupported block type
│
│   on .terraform/modules/eks_blueprints/modules/eks-managed-node-group/main.tf line 112, in resource "aws_launch_template" "this":
│  112:   dynamic "elastic_inference_accelerator" {
│
│ Blocks of type "elastic_inference_accelerator" are not expected here.
╵
╷
│ Error: Unsupported block type
│
│   on .terraform/modules/eks_blueprints/modules/self-managed-node-group/main.tf line 115, in resource "aws_launch_template" "this":
│  115:   dynamic "elastic_gpu_specifications" {
│
│ Blocks of type "elastic_gpu_specifications" are not expected here.
╵
╷
│ Error: Unsupported block type
│
│   on .terraform/modules/eks_blueprints/modules/self-managed-node-group/main.tf line 123, in resource "aws_launch_template" "this":
│  123:   dynamic "elastic_inference_accelerator" {
│
│ Blocks of type "elastic_inference_accelerator" are not expected here.
╵

```
This PR addresses this issue.